### PR TITLE
Fix bad reference to renamed '@message' field.

### DIFF
--- a/lib/logstash/filters/json.rb
+++ b/lib/logstash/filters/json.rb
@@ -18,7 +18,7 @@ class LogStash::Filters::Json < LogStash::Filters::Base
   # [source,ruby]
   #     source => source_field
   #
-  # For example, if you have JSON data in the @message field:
+  # For example, if you have JSON data in the `message` field:
   # [source,ruby]
   #     filter {
   #       json {
@@ -26,7 +26,7 @@ class LogStash::Filters::Json < LogStash::Filters::Base
   #       }
   #     }
   #
-  # The above would parse the json from the @message field
+  # The above would parse the json from the `message` field
   config :source, :validate => :string, :required => true
 
   # Define the target field for placing the parsed data. If this setting is


### PR DESCRIPTION
That field has been called plain 'message' for a while now. Also
surround the field name with backticks for consistency with other
field name references.