### PR TITLE
make "tags" to be array like "tags" in grok filter

### DIFF
--- a/lib/logstash/filters/json.rb
+++ b/lib/logstash/filters/json.rb
@@ -90,7 +90,9 @@ class LogStash::Filters::Json < LogStash::Filters::Base
 
       filter_matched(event)
     rescue => e
-      event.tag("_jsonparsefailure")
+      tag = "_jsonparsefailure"
+      event["tags"] ||= []
+      event["tags"] << tag unless event["tags"].include?(tag)
       @logger.warn("Trouble parsing json", :source => @source,
                    :raw => event[@source], :exception => e)
       return

--- a/logstash-filter-json.gemspec
+++ b/logstash-filter-json.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-json'
-  s.version         = '0.1.5'
+  s.version         = '0.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This is a JSON parsing filter. It takes an existing field which contains JSON and expands it into an actual data structure within the Logstash event."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This pull request will make json filter to be the same as "tags" in grok filter, which fix this situation:
```
{
     "tags" => "_jsonparsefailure_grokparsefailure",
     "@version" => "1",
     "@timestamp" => "2015-04-13T09:06:48.887Z",
     ...
}
```

if _jsonparsefailure and _grokparsefailure occur in the same time , the correct output will be:
```
{
     "tags" => [
         [0] "_jsonparsefailure",
         [1] "_grokparsefailure"
     ],
     "@version" => "1",
     "@timestamp" => "2015-04-13T09:06:48.887Z",
     ...
}
```