### PR TITLE
Handles ArrayList when parsing JSON

### DIFF
--- a/lib/logstash/filters/json.rb
+++ b/lib/logstash/filters/json.rb
@@ -67,7 +67,7 @@ class LogStash::Filters::Json < LogStash::Filters::Base
       parsed = LogStash::Json.load(source)
       # If your parsed JSON is an array, we can't merge, so you must specify a
       # destination to store the JSON, so you will get an exception about
-      if parsed.kind_of?(Java::JavaUtil::ArrayList) && @target.nil?
+      if parsed.kind_of?(Array) && @target.nil?
         raise('Parsed JSON arrays must have a destination in the configuration')
       elsif @target.nil?
         event.to_hash.merge! parsed


### PR DESCRIPTION
There's a (todo) in the source about not being able to parse JSON arrays because we use `merge!` to merge the JSON and the destination. Well, my new input source has an array as the base type, so I kind of need that functionality now :D.

### Questions ###

* ~~Are there instances where `parsed.kind_of?(Java::JavaUtil::ArrayList)` would fail? Maybe because we weren't running inside of JRuby?~~
* Is it okay to raise an error message like that? Still gets the normal parse failure tag and you get a little more insight as to why it's failing.