### PR TITLE
do not assume event field values as mutable and code cleanups and proper timestamp handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 2.0.3
+ - Refactored field references, better timestamp handling, code & specs cleanups
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/logstash-filter-json.gemspec
+++ b/logstash-filter-json.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-json'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This is a JSON parsing filter. It takes an existing field which contains JSON and expands it into an actual data structure within the Logstash event."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
- code cleanup
- do not assume event field values as mutable
- proper timestamp handling
- related specs

relates to elastic/logstash#4264 and elastic/logstash#4191
requires elastic/logstash#4279 to pass specs under Java Event