### PR TITLE
Add `skip_on_invalid_json` option to allow non-json source w/o warnings

### DIFF
--- a/lib/logstash/filters/json.rb
+++ b/lib/logstash/filters/json.rb
@@ -59,8 +59,8 @@ class LogStash::Filters::Json < LogStash::Filters::Base
   # successful match
   config :tag_on_failure, :validate => :array, :default => ["_jsonparsefailure"]
 
-  # Allow to quietly fall-back to plain-text (aka skip the filter without warnings and tags)
-  config :fallback_mode, :validate => :boolean, :default => false
+  # Allow to skip filter on invalid json (allows to handle json and non-json data without warnings)
+  config :skip_on_invalid_json, :validate => :boolean, :default => false
 
   def register
     # Nothing to do here
@@ -75,7 +75,7 @@ class LogStash::Filters::Json < LogStash::Filters::Base
     begin
       parsed = LogStash::Json.load(source)
     rescue => e
-      unless @fallback_mode
+      unless @skip_on_invalid_json
         @tag_on_failure.each{|tag| event.tag(tag)}
         @logger.warn("Error parsing json", :source => @source, :raw => source, :exception => e)
       end

--- a/lib/logstash/filters/json.rb
+++ b/lib/logstash/filters/json.rb
@@ -59,6 +59,9 @@ class LogStash::Filters::Json < LogStash::Filters::Base
   # successful match
   config :tag_on_failure, :validate => :array, :default => ["_jsonparsefailure"]
 
+  # Allow to quietly fall-back to plain-text (aka skip the filter without warnings and tags)
+  config :fallback_mode, :validate => :boolean, :default => false
+
   def register
     # Nothing to do here
   end
@@ -72,8 +75,10 @@ class LogStash::Filters::Json < LogStash::Filters::Base
     begin
       parsed = LogStash::Json.load(source)
     rescue => e
-      @tag_on_failure.each{|tag| event.tag(tag)}
-      @logger.warn("Error parsing json", :source => @source, :raw => source, :exception => e)
+      unless @fallback_mode
+        @tag_on_failure.each{|tag| event.tag(tag)}
+        @logger.warn("Error parsing json", :source => @source, :raw => source, :exception => e)
+      end
       return
     end
 

--- a/spec/filters/json_spec.rb
+++ b/spec/filters/json_spec.rb
@@ -176,10 +176,10 @@ describe LogStash::Filters::Json do
     end
   end
 
-  describe "parse mixture of json an non-json content (fallback mode)" do
+  describe "parse mixture of json an non-json content (skip_on_invalid_json)" do
     subject(:filter) {  LogStash::Filters::Json.new(config)  }
 
-    let(:config) { {"source" => "message", "remove_field" => ["message"], "fallback_mode" => fallback_mode} }
+    let(:config) { {"source" => "message", "remove_field" => ["message"], "skip_on_invalid_json" => skip_on_invalid_json} }
     let(:event) { LogStash::Event.new("message" => message) }
 
     before(:each) do
@@ -190,8 +190,8 @@ describe LogStash::Filters::Json do
 
     let(:message) { "this is not a json message" }
 
-    context "with fallback_mode off" do
-      let(:fallback_mode) { false }
+    context "with `skip_on_invalid_json` set to false" do
+      let(:skip_on_invalid_json) { false }
 
       it "sends a warning to the logger" do
         expect(filter.logger).to have_received(:warn).with("Error parsing json", anything())
@@ -206,8 +206,8 @@ describe LogStash::Filters::Json do
       end
     end
 
-    context "with fallback_mode on" do
-      let(:fallback_mode) { true }
+    context "with `skip_on_invalid_json` set to true" do
+      let(:skip_on_invalid_json) { true }
 
       it "sends no warning" do
         expect(filter.logger).to_not have_received(:warn)


### PR DESCRIPTION
Hi,

we're using logstash in our setup to process logs from our docker-infrastrucutre (with the GELF logging-driver and the `gelf` input in logstash).

The biggest part of our own applications running inside the docker-containers are logging in JSON format already so we're using the `json` filter to split the json-document provided in `short_message` field into separate fields in elasticsearch.

For each log-entry produced by a docker-container which is not in JSON format (e.g. parts of our applications where we don't can have impact on the log-format or third-party application) the `json` filter is producing a warning in the log-file:

```
logstash_1      | {:timestamp=>"2016-03-29T07:55:09.158000+0000", :message=>"Error parsing json", :source=>"short_message", :raw=>"ActionController::RoutingError (No route matches [GET] \"/\"):", :exception=>#<LogStash::Json::ParserError: Unrecognized token 'ActionController': was expecting ('true', 'false' or 'null')
logstash_1      |  at [Source: [B@209c8fc2; line: 1, column: 18]>, :level=>:warn}
logstash_1      | {:timestamp=>"2016-03-29T07:55:09.158000+0000", :message=>"Error parsing json", :source=>"short_message", :raw=>"  actionpack (4.2.5.2) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'", :exception=>#<LogStash::Json::ParserError: Unrecognized token 'actionpack': was expecting ('true', 'false' or 'null')
logstash_1      |  at [Source: [B@302c32ba; line: 1, column: 14]>, :level=>:warn}
```

I've added a new config-option to the `json` filter called `fall_backmode` (default `false`) which allows to turn of this warnings and also prevent the filter from tagging the event with `"_jsonparsefailure"`.

Would be great if we can get this change (or any variation of it) upstream so we won't have to use a fork of this plugin in our setup.

I'll sign the CLA before a potential merge - hope that's ok.

Cheers, Klaus
