### PR TITLE
adjust specs from #24 to be compatible with new event api

### DIFF
--- a/spec/filters/json_spec.rb
+++ b/spec/filters/json_spec.rb
@@ -198,11 +198,11 @@ describe LogStash::Filters::Json do
       end
 
       it "keeps the source field" do
-        expect(event["message"]).to eq message
+        expect(event.get("message")).to eq message
       end
 
       it "adds a parse-error tag" do
-        expect(event["tags"]).to eq ["_jsonparsefailure"]
+        expect(event.get("tags")).to eq ["_jsonparsefailure"]
       end
     end
 
@@ -214,11 +214,11 @@ describe LogStash::Filters::Json do
       end
 
       it "keeps the source field" do
-        expect(event["message"]).to eq message
+        expect(event.get("message")).to eq message
       end
 
       it "does not add a parse-error tag" do
-        expect(event["tags"]).to be_nil
+        expect(event.get("tags")).to be_nil
       end
     end
   end


### PR DESCRIPTION
Looks like my previous PR #24 wasn't up to date with the latest master when it was merged.
The change introduced in 79bef06 in combination with my PR caused some of my newly introduced specs to fail because of the old event API being used to check the event's attributes.

ping @jordansissel, @ph 