### PR TITLE
bump to 3.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.6
+  - Updated documentation with some clarifications and fixes
+
 ## 3.0.5
   - Update gemspec summary
 

--- a/logstash-filter-json.gemspec
+++ b/logstash-filter-json.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-json'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses JSON events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
```
% git lg v3.0.5..
* 4ecf5db - (origin/master, master) [skip ci] Travis: update LOGSTASH_BRANCH from 6.[0..4] to 6.5 (4 weeks ago) <Rob Bavey>
* e69a8e3 - pin bundler version to < 2 (5 weeks ago) <Rob Bavey>
* d9c9482 - [skip ci] update license to 2018 (1 year, 1 month ago) <Joao Duarte>
* c42d0ef - Merge pull request #35 from lingfish/patch-1 (1 year, 2 months ago) <Jake Landis>
* 9fc2503 - Various nitpicks and typos. (1 year, 2 months ago) <Jason Lingohr>
```