### PR TITLE
Fix tag on failure test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1
+  - Fix tag on failure test [#52](https://github.com/logstash-plugins/logstash-filter-json/pull/52)
+
 ## 3.2.0
  - Feat: check target is set in ECS mode [#49](https://github.com/logstash-plugins/logstash-filter-json/pull/49)
  - Refactor: logging improvements to print event details in debug mode

--- a/logstash-filter-json.gemspec
+++ b/logstash-filter-json.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-json'
-  s.version         = '3.2.0'
+  s.version         = '3.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses JSON events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/json_spec.rb
+++ b/spec/filters/json_spec.rb
@@ -62,8 +62,9 @@ describe LogStash::Filters::Json do
   end
 
   logstash_version = Gem::Version.create(LOGSTASH_CORE_VERSION)
-
-  if (Gem::Requirement.create('>= 7.0').satisfied_by?(logstash_version) ||
+  
+  # Field Reference can handle special characters since 8.3.0
+  if ((Gem::Requirement.create('>= 7.0').satisfied_by?(logstash_version) && Gem::Requirement.create('< 8.3').satisfied_by?(logstash_version)) ||
      (Gem::Requirement.create('~> 6.4').satisfied_by?(logstash_version) && LogStash::SETTINGS.get('config.field_reference.parser') == 'STRICT'))
     describe "unsupported field name using `target`" do
       config <<-CONFIG


### PR DESCRIPTION
Field Reference can handle special characters in 8.3.0. This commit excludes the failed test from 8.3+

Related:
https://github.com/elastic/logstash/issues/11941

Close #55 
