### PR TITLE
fix:skip_on_invalid_json confit with tag_on_faliure

### DIFF
--- a/lib/logstash/filters/json.rb
+++ b/lib/logstash/filters/json.rb
@@ -85,8 +85,9 @@ class LogStash::Filters::Json < LogStash::Filters::Base
     rescue => e
       unless @skip_on_invalid_json
         @logger.warn("Error parsing json", :source => @source, :raw => source, :exception => e)
+      else
+        _do_tag_on_failure(event)
       end
-      _do_tag_on_failure(event)
       return
     end
 

--- a/lib/logstash/filters/json.rb
+++ b/lib/logstash/filters/json.rb
@@ -84,9 +84,9 @@ class LogStash::Filters::Json < LogStash::Filters::Base
       parsed = LogStash::Json.load(source)
     rescue => e
       unless @skip_on_invalid_json
-        _do_tag_on_failure(event)
         @logger.warn("Error parsing json", :source => @source, :raw => source, :exception => e)
       end
+      _do_tag_on_failure(event)
       return
     end
 


### PR DESCRIPTION
It is werid that if the skip_on_invalid_json = true, the event tag is not set. I change the logic to make skip_on_invalid_json and tag_on_failure independent.